### PR TITLE
Added prolog facts for perception calls when querying for currently visi...

### DIFF
--- a/cram_plan_library/cram-plan-library.asd
+++ b/cram_plan_library/cram-plan-library.asd
@@ -67,5 +67,6 @@
                            "at-location"
                            "utilities"
                            "with-designators"))
+             (:file "facts" :depends-on ("package" "goal-declarations" "utilities" "perceive-object"))
              (:file "perform" :depends-on ("package" "goal-declarations"))
              (:file "utilities" :depends-on ("package"))))))

--- a/cram_plan_library/src/facts.lisp
+++ b/cram_plan_library/src/facts.lisp
@@ -1,0 +1,38 @@
+;;; Copyright (c) 2014, Jan Winkler <winkler@cs.uni-bremen.de>
+;;; All rights reserved.
+;;; 
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;; 
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of Universität Bremen, nor the names of its
+;;;       contributors may be used to endorse or promote products derived from
+;;;       this software without specific prior written permission.
+;;; 
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :plan-lib)
+
+(def-fact-group plan-lib-facts ()
+
+  (<- (currently-visible-objects ?template ?objects)
+    (lisp-fun perceive-object currently-visible
+              ?template ?objects))
+
+  (<- (currently-visible-objects ?objects)
+    (lisp-fun make-designator object () ?template)
+    (currently-visible-objects ?template ?objects)))

--- a/cram_plan_library/src/package.lisp
+++ b/cram_plan_library/src/package.lisp
@@ -38,6 +38,8 @@
         #:cram-plan-knowledge
         #:cram-plan-failures
         #:alexandria)
+  (:import-from #:cram-reasoning #:<- #:def-fact-group
+                #:lisp-fun #:lisp-pred)
   (:nicknames :plan-lib)
   (:export #:achieve
            #:perform
@@ -69,7 +71,9 @@
            ;; designator generation
            #:with-designators
            #:a
-           #:an)
+           #:an
+           ;; prolog facts
+           #:currently-visible-objects)
   (:desig-properties #:to #:see #:obj #:of #:reach #:type #:trajectory
                      #:pose #:open #:side #:grasp #:lift #:carry :reach
                      #:location #:at #:parked #:pose #:close #:gripper


### PR DESCRIPTION
...ble objects

Use it like this:

``` lisp
(crs:prolog `(currently-visible-objects ?template ?obj))
```

The `?template` parameter is an object designator holding the object description prototype to pass to the perception subplan. In case you don't want to specify a template, omit the parameter:

``` lisp
(crs:prolog `(currently-visible-objects ?obj))
```

The objects found are then bound to the parameter `?obj` for each result.
