### PR TITLE
plan lib: got rid of zombie exports

### DIFF
--- a/cram_plan_library/src/package.lisp
+++ b/cram_plan_library/src/package.lisp
@@ -58,10 +58,6 @@
            #:examine
            #:obstacles-found
            #:robot
-           #:maybe-run-process-modules
-           #:run-process-modules
-           #:start-process-modules
-           #:stop-process-modules
            ;; rete and occasions
            #:object-picked-up
            #:object-in-hand-failure


### PR DESCRIPTION
It confuses my autocomplete.
Couldn't find the symbols in the package anymore, so I guess they migrated somewhere.
