### PR TITLE
Changed cffi_ros_utils/ros-libraries.lisp::ros-library-paths to actually...

### DIFF
--- a/cffi_ros_utils/src/ros-libraries.lisp
+++ b/cffi_ros_utils/src/ros-libraries.lisp
@@ -34,15 +34,15 @@
   "Returns the list of library paths as exported by the ROS package
   with name `pkg-name' in its cpp tag. This function parses the lflags
   attribute and collects all library paths specified by -L."
-  (mapcar (lambda (seq)
-            (subseq seq 2))
+  (apply #'append (mapcar (lambda (seq)
+            (split-sequence:split-sequence #\: (subseq seq 2) :remove-empty-subseqs t))
           (delete-if-not
            (lambda (seq)
              (equal (subseq seq 0 2) "-L"))
            (split-sequence:split-sequence
-            #\Space
-            (car (ros-load:rospack "export" "--lang=cpp" "--attrib=lflags" pkg-name))
-            :remove-empty-subseqs t))))
+             #\Space
+             (car (ros-load:rospack "export" "--lang=cpp" "--attrib=lflags" pkg-name))
+             :remove-empty-subseqs t)))))
 
 (defun ros-include-paths (pkg-name)
   "Returns the list of include paths as exported by the ROS package


### PR DESCRIPTION
... return a list of paths if one is defined in the export tag.

This was done because a definition like "-Lpath1:path2" confused the old version of the function (it returned "path1:path2" as a single string).

This change is also important for cl_bullet catkinization.
