### PR TITLE
Revert "Making sure that the correct header files are included for Hydro"

### DIFF
--- a/cram_physics_utils/src/assimp-grovel.lisp
+++ b/cram_physics_utils/src/assimp-grovel.lisp
@@ -28,11 +28,11 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(include "assimp/assimp.h")
-(include "assimp/aiMesh.h")
-(include "assimp/aiScene.h")
-(include "assimp/aiMaterial.h")
-(include "assimp/aiPostProcess.h")
+(include "assimp/cimport.h")
+(include "assimp/mesh.h")
+(include "assimp/scene.h")
+(include "assimp/material.h")
+(include "assimp/postprocess.h")
 
 (in-package :physics-utils)
 


### PR DESCRIPTION
In Indigo on Ubuntu 14.04 the headers are actually correct the way they are.
This reverts commit 1e8127445e972838b44664bffd0bc2bac6ff0d6a.