### PR TITLE
[cram_physics_utils] backwards compatibility patch for assimp headers

### DIFF
--- a/cram_physics_utils/.gitattributes
+++ b/cram_physics_utils/.gitattributes
@@ -1,0 +1,1 @@
+src/assimp-grovel.lisp filter=gitignore

--- a/cram_physics_utils/.gitignore
+++ b/cram_physics_utils/.gitignore
@@ -1,3 +1,4 @@
 src/assimp-grovel
 src/assimp-grovel.c
 src/assimp-grovel.grovel-tmp.lisp
+patch/backup

--- a/cram_physics_utils/CMakeLists.txt
+++ b/cram_physics_utils/CMakeLists.txt
@@ -1,5 +1,25 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cram_physics_utils)
 find_package(catkin REQUIRED)
-
 catkin_package()
+
+# assimp headers have different names between different Ubuntu versions.
+# We patch the src/assimp-grovel.lisp file when necessary to adjust to that.
+find_file(HAVE_CIMPORT_H assimp/cimport.h)
+if(NOT HAVE_CIMPORT_H)
+  find_file(HAVE_ASSIMP_H assimp/assimp.h)
+  if(HAVE_ASSIMP_H)
+    if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/patch/backup)
+      execute_process(COMMAND patch -d ${CMAKE_CURRENT_SOURCE_DIR} -p0 -N -r -
+        -b -B patch/backup/
+        -i patch/assimp-grovel-12.04.patch)
+      execute_process(COMMAND git config filter.gitignore.clean
+        "patch -d ${CMAKE_CURRENT_SOURCE_DIR} -p0 -N -r - -R -s -i patch/assimp-grovel-12.04.patch -o -"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+      execute_process(COMMAND git config filter.gitignore.smudge cat
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    endif()
+  else()
+    message(SEND_ERROR "Can't find assimp headers.")
+  endif()
+endif()

--- a/cram_physics_utils/CMakeLists.txt
+++ b/cram_physics_utils/CMakeLists.txt
@@ -18,6 +18,8 @@ if(NOT HAVE_CIMPORT_H)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
       execute_process(COMMAND git config filter.gitignore.smudge cat
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+      execute_process(COMMAND git add src/assimp-grovel.lisp
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     endif()
   else()
     message(SEND_ERROR "Can't find assimp headers.")

--- a/cram_physics_utils/patch/assimp-grovel-12.04.patch
+++ b/cram_physics_utils/patch/assimp-grovel-12.04.patch
@@ -1,0 +1,19 @@
+--- src/assimp-grovel.lisp	2015-02-16 21:26:09.564876613 +0100
++++ src/assimp-grovel-12.04.lisp	2015-02-16 21:24:49.040878119 +0100
+@@ -28,11 +28,11 @@
+ ;;; POSSIBILITY OF SUCH DAMAGE.
+ ;;;
+ 
+-(include "assimp/cimport.h")
+-(include "assimp/mesh.h")
+-(include "assimp/scene.h")
+-(include "assimp/material.h")
+-(include "assimp/postprocess.h")
++(include "assimp/assimp.h")
++(include "assimp/aiMesh.h")
++(include "assimp/aiScene.h")
++(include "assimp/aiMaterial.h")
++(include "assimp/aiPostProcess.h")
+ 
+ (in-package :physics-utils)
+ 


### PR DESCRIPTION
* added a patch diff file
* added a command to cmakelists to execute the patch and create a backup
* add a git ignore rule for the backup
* added a git attribue filter to make sure the patched file doesn't appear in the upstream

This patching business turned out to be much more complex than expected. Well, at least I learned Git attributes... Next time we should really use CMake configure together with simple .gitignore instead of patching. Don't see any advantage of using patching on files of the source tree.