### PR TITLE
tf -> tf2

### DIFF
--- a/continuous_interaction/src/continuous.lisp
+++ b/continuous_interaction/src/continuous.lisp
@@ -88,19 +88,19 @@
                        (offset-angle 0.0)
                        grasp-type
                        (center-offset
-                        (tf:make-identity-vector)))
+                        (cl-transforms:make-identity-vector)))
   (loop for i from 0 below segments
         as current-angle = (+ (* 2 pi (float (/ i segments)))
                               offset-angle)
-        as handle-pose = (tf:make-pose
-                          (tf:make-3d-vector
+        as handle-pose = (cl-transforms:make-pose
+                          (cl-transforms:make-3d-vector
                            (+ (* distance-from-center (cos current-angle))
-                              (tf:x center-offset))
+                              (cl-transforms:x center-offset))
                            (+ (* distance-from-center (sin current-angle))
-                              (tf:y center-offset))
+                              (cl-transforms:y center-offset))
                            (+ 0.0
-                              (tf:z center-offset)))
-                          (tf:euler->quaternion
+                              (cl-transforms:z center-offset)))
+                          (cl-transforms:euler->quaternion
                            :ax ax :ay ay :az (+ az current-angle)))
         as handle-object = (make-designator
                             'cram-designators:object

--- a/cram_plan_knowledge/src/occasions.lisp
+++ b/cram_plan_knowledge/src/occasions.lisp
@@ -59,3 +59,13 @@
 (defun holds-occasion (occ)
   (deprecate "HOLDS-OCCASION is deprecated.")
   (force-ll (rete-holds occ #'occasion-equal-test)))
+
+(defmethod holds (occasion &optional time-specification)
+  (if time-specification
+      (prolog `(holds ?_  ,occasion ,time-specification))
+      (prolog `(holds ,occasion))))
+
+
+(def-fact-group occasions (holds)
+  (<- (holds ?occasion)
+    (call ?occasion)))

--- a/cram_plan_knowledge/src/package.lisp
+++ b/cram_plan_knowledge/src/package.lisp
@@ -39,7 +39,6 @@
           #:cram-execution-trace)
   (:nicknames #:plan-knowledge)
   (:shadowing-import-from #:cpl #:name)
-  (:shadowing-import-from #:cram-utilities #:extremum)
   (:import-from #:designators-ros pose pose-stamped)
   (:shadow event)
   (:export #:clear-belief

--- a/cram_plan_library/src/achieve-everyday-activities.lisp
+++ b/cram_plan_library/src/achieve-everyday-activities.lisp
@@ -58,12 +58,14 @@
                (sem-map-utils:pose semantic-handle-reference))
              (handle-pose-map
                (tf:copy-pose-stamped
-                (cl-tf2:ensure-pose-stamped-transformed
-                 cram-roslisp-common::*tf2-buffer*
-                 handle-pose
-                 "map" :use-current-ros-time t)
-                :orientation (tf:orientation
-                              semantic-handle-pose))))
+                (cl-tf2:transform-pose
+                 cram-roslisp-common:*tf2-buffer*
+                 :pose (cl-tf-datatypes:copy-pose-stamped
+                        handle-pose
+                        :stamp (roslisp:ros-time)) ; <- use current rostime
+                 :target-frame designators-ros:*fixed-frame*
+                 :timeout cram-roslisp-common:*tf-default-timeout*)
+                :orientation (tf:orientation semantic-handle-pose))))
         (make-designator
          'object `((desig-props::name ,?semantic-name)
                    (desig-props::type desig-props::semantic-handle)

--- a/cram_plan_library/src/achieve-everyday-activities.lisp
+++ b/cram_plan_library/src/achieve-everyday-activities.lisp
@@ -60,11 +60,10 @@
                (tf:copy-pose-stamped
                 (cl-tf2:transform-pose
                  cram-roslisp-common:*tf2-buffer*
-                 :pose (cl-tf-datatypes:copy-pose-stamped
-                        handle-pose
-                        :stamp (roslisp:ros-time)) ; <- use current rostime
+                 :pose handle-pose
                  :target-frame designators-ros:*fixed-frame*
-                 :timeout cram-roslisp-common:*tf-default-timeout*)
+                 :timeout cram-roslisp-common:*tf-default-timeout*
+                 :use-current-ros-time t)
                 :orientation (tf:orientation semantic-handle-pose))))
         (make-designator
          'object `((desig-props::name ,?semantic-name)

--- a/cram_plan_library/src/achieve-object-manipulation.lisp
+++ b/cram_plan_library/src/achieve-object-manipulation.lisp
@@ -66,8 +66,8 @@
                  look-for-object
                  :generators (((look-at-pose)
                                `(,(reference obj-loc))))
-                 :features ((look-x (tf:x (tf:origin look-at-pose)))
-                            (look-y (tf:y (tf:origin look-at-pose))))
+                 :features ((look-x (cl-transforms:x (cl-transforms:origin look-at-pose)))
+                            (look-y (cl-transforms:y (cl-transforms:origin look-at-pose))))
                  :constraints ((cram-plan-failures::objectnotfound
                                 (< cut::predicted-failure 0.5)))
                  :attempts 2
@@ -96,8 +96,8 @@
                                (make-designator
                                 'location
                                 `((of ,perceived-object)))))))
-             :features ((look-x (tf:x (tf:origin look-at-pose)))
-                        (look-y (tf:y (tf:origin look-at-pose))))
+             :features ((look-x (cl-transforms:x (cl-transforms:origin look-at-pose)))
+                        (look-y (cl-transforms:y (cl-transforms:origin look-at-pose))))
              :constraints ((cram-plan-failures::objectnotfound
                             (< cut::predicted-failure 0.5)))
              :attempts 2

--- a/cram_plan_library/src/achieve-ptu.lisp
+++ b/cram_plan_library/src/achieve-ptu.lisp
@@ -40,7 +40,7 @@
                               (ecase ?pose
                                 (:forward
                                  `((to see)
-                                   (pose ,(tf:make-pose-stamped
+                                   (pose ,(cl-tf-datatypes:make-pose-stamped
                                            "/base_link" 0.0
                                            (cl-transforms:make-3d-vector
                                             3.0 0.0 1.5)

--- a/cram_plan_library/src/achieve-ptu.lisp
+++ b/cram_plan_library/src/achieve-ptu.lisp
@@ -41,7 +41,8 @@
                                 (:forward
                                  `((to see)
                                    (pose ,(cl-tf-datatypes:make-pose-stamped
-                                           "/base_link" 0.0
+                                           designators-ros:*robot-base-frame*
+                                           0.0
                                            (cl-transforms:make-3d-vector
                                             3.0 0.0 1.5)
                                            (cl-transforms:make-quaternion

--- a/cram_plan_library/src/at-location.lisp
+++ b/cram_plan_library/src/at-location.lisp
@@ -80,7 +80,7 @@ designator."
                          nil at-location-task
                          (lambda  ()
                            (pulse robot-location-changed-fluent)))))))))
-      (tf:with-transforms-changed-callback (*tf* #'set-current-location)
+      (cl-tf2:with-transforms-changed-callbacks (*tf2-broadcaster* #'set-current-location)
         (with-equate-fluent (loc-var designator-updated)
           (loop
             for navigation-done = (make-fluent :value nil)

--- a/cram_plan_library/src/package.lisp
+++ b/cram_plan_library/src/package.lisp
@@ -39,7 +39,6 @@
         #:cram-plan-knowledge
         #:cram-plan-failures
         #:alexandria)
-  (:shadowing-import-from #:cram-utilities #:extremum)
   (:nicknames :plan-lib)
   (:export #:achieve
            #:perform

--- a/cram_plan_library/src/package.lisp
+++ b/cram_plan_library/src/package.lisp
@@ -65,7 +65,7 @@
            #:object-picked-up
            #:object-in-hand-failure
            #:object-not-found-failure)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer* *tf2-broadcaster*)
   (:desig-properties #:to #:see #:obj #:of #:reach #:type #:trajectory
                      #:pose #:open #:side #:grasp #:lift #:carry :reach
                      #:location #:at #:parked #:pose #:close #:gripper

--- a/cram_plan_library/src/utilities.lisp
+++ b/cram_plan_library/src/utilities.lisp
@@ -44,13 +44,13 @@
   ;; to fix it in the future.
   (let ((robot-pose
           (cl-tf2:ensure-pose-stamped-transformed
-           *tf2*
-           (tf:make-pose-stamped
+           *tf2-buffer*
+           (cl-tf-datatypes:make-pose-stamped
             designators-ros:*robot-base-frame* 0.0
             (cl-transforms:make-identity-vector)
             (cl-transforms:make-identity-rotation))
            designators-ros:*fixed-frame*)))
-    (tf:copy-pose-stamped
+    (cl-tf-datatypes:copy-pose-stamped
      robot-pose
      :origin (cl-transforms:copy-3d-vector
               (cl-transforms:origin robot-pose) :z 0.0))))

--- a/cram_plan_library/src/utilities.lisp
+++ b/cram_plan_library/src/utilities.lisp
@@ -43,13 +43,14 @@
   ;; zero. This is an ugly hack that I feel bad about. Someone needs
   ;; to fix it in the future.
   (let ((robot-pose
-          (cl-tf2:ensure-pose-stamped-transformed
+          (cl-tf2:transform-pose
            *tf2-buffer*
-           (cl-tf-datatypes:make-pose-stamped
-            designators-ros:*robot-base-frame* 0.0
-            (cl-transforms:make-identity-vector)
-            (cl-transforms:make-identity-rotation))
-           designators-ros:*fixed-frame*)))
+           :pose (cl-tf-datatypes:make-pose-stamped
+                  designators-ros:*robot-base-frame* 0.0
+                  (cl-transforms:make-identity-vector)
+                  (cl-transforms:make-identity-rotation))
+           :target-frame designators-ros:*fixed-frame*
+           :timeout cram-roslisp-common:*tf-default-timeout*)))
     (cl-tf-datatypes:copy-pose-stamped
      robot-pose
      :origin (cl-transforms:copy-3d-vector

--- a/cram_roslisp_common/src/package.lisp
+++ b/cram_roslisp_common/src/package.lisp
@@ -39,4 +39,5 @@
            #:lispify-ros-name
            #:rosify-lisp-name
            #:*tf*
-           #:*tf2*))
+           #:*tf2*
+           #:*tf2-tb*))

--- a/cram_roslisp_common/src/package.lisp
+++ b/cram_roslisp_common/src/package.lisp
@@ -40,4 +40,4 @@
            #:rosify-lisp-name
            #:*tf*
            #:*tf2*
-           #:*tf2-tb*))
+           #:*tf2-broadcaster*))

--- a/cram_roslisp_common/src/package.lisp
+++ b/cram_roslisp_common/src/package.lisp
@@ -39,4 +39,5 @@
            #:lispify-ros-name
            #:rosify-lisp-name
            #:*tf2-buffer*
-           #:*tf2-broadcaster*))
+           #:*tf2-broadcaster*
+           #:*tf-default-timeout*))

--- a/cram_roslisp_common/src/package.lisp
+++ b/cram_roslisp_common/src/package.lisp
@@ -38,6 +38,5 @@
            #:shutdown-ros
            #:lispify-ros-name
            #:rosify-lisp-name
-           #:*tf*
-           #:*tf2*
+           #:*tf2-buffer*
            #:*tf2-broadcaster*))

--- a/cram_roslisp_common/src/tf.lisp
+++ b/cram_roslisp_common/src/tf.lisp
@@ -32,11 +32,11 @@
 
 (defvar *tf* nil)
 (defvar *tf2* nil)
-(defvar *tf2-tb* nil)
+(defvar *tf2-broadcaster* nil)
 
 (defun ros-tf-init ()
   (setf *tf* (make-instance 'cl-tf:transform-listener))
   (setf *tf2* (make-instance 'cl-tf2:buffer-client))
-  (setf *tf2-tb* (cl-tf2:make-transform-broadcaster :topic "/tf")))
+  (setf *tf2-broadcaster* (cl-tf2:make-transform-broadcaster :topic "/tf")))
 
 (roslisp-utilities:register-ros-init-function ros-tf-init)

--- a/cram_roslisp_common/src/tf.lisp
+++ b/cram_roslisp_common/src/tf.lisp
@@ -30,13 +30,11 @@
 
 (in-package :cram-roslisp-common)
 
-(defvar *tf* nil)
-(defvar *tf2* nil)
+(defvar *tf2-buffer* nil)
 (defvar *tf2-broadcaster* nil)
 
 (defun ros-tf-init ()
-  (setf *tf* (make-instance 'cl-tf:transform-listener))
-  (setf *tf2* (make-instance 'cl-tf2:buffer-client))
+  (setf *tf2-buffer* (make-instance 'cl-tf2:buffer-client))
   (setf *tf2-broadcaster* (cl-tf2:make-transform-broadcaster :topic "/tf")))
 
 (roslisp-utilities:register-ros-init-function ros-tf-init)

--- a/cram_roslisp_common/src/tf.lisp
+++ b/cram_roslisp_common/src/tf.lisp
@@ -32,6 +32,7 @@
 
 (defvar *tf2-buffer* nil)
 (defvar *tf2-broadcaster* nil)
+(defparameter *tf-default-timeout* 0.0 "How long to wait until a tansform in secs.")
 
 (defun ros-tf-init ()
   (setf *tf2-buffer* (make-instance 'cl-tf2:buffer-client))

--- a/cram_roslisp_common/src/tf.lisp
+++ b/cram_roslisp_common/src/tf.lisp
@@ -37,6 +37,6 @@
 (defun ros-tf-init ()
   (setf *tf* (make-instance 'cl-tf:transform-listener))
   (setf *tf2* (make-instance 'cl-tf2:buffer-client))
-  (setf *tf2* (cl-tf2:make-transform-broadcaster :topic "/tf")))
+  (setf *tf2-tb* (cl-tf2:make-transform-broadcaster :topic "/tf")))
 
 (roslisp-utilities:register-ros-init-function ros-tf-init)

--- a/cram_roslisp_common/src/tf.lisp
+++ b/cram_roslisp_common/src/tf.lisp
@@ -32,9 +32,11 @@
 
 (defvar *tf* nil)
 (defvar *tf2* nil)
+(defvar *tf2-tb* nil)
 
 (defun ros-tf-init ()
   (setf *tf* (make-instance 'cl-tf:transform-listener))
-  (setf *tf2* (make-instance 'cl-tf2:buffer-client)))
+  (setf *tf2* (make-instance 'cl-tf2:buffer-client))
+  (setf *tf2* (cl-tf2:make-transform-broadcaster :topic "/tf")))
 
 (roslisp-utilities:register-ros-init-function ros-tf-init)

--- a/cram_task_knowledge/src/package.lisp
+++ b/cram_task_knowledge/src/package.lisp
@@ -36,7 +36,6 @@
         #:roslisp
         #:cram-roslisp-common
         #:alexandria)
-  (:shadowing-import-from #:cram-utilities #:extremum)
   (:export table-setting-object
            situation?
            meal-time)

--- a/designators_ros/src/designator-extensions.lisp
+++ b/designators_ros/src/designator-extensions.lisp
@@ -48,8 +48,8 @@
 
 (defgeneric ensure-pose-stamped (position-object frame-id stamp)
   (:method ((pose cl-transforms:pose) frame-id stamp)
-    (tf:pose->pose-stamped frame-id stamp pose))
-  (:method ((pose-stamped tf:pose-stamped) frame-id stamp)
+    (cl-tf-datatypes:pose->pose-stamped frame-id stamp pose))
+  (:method ((pose-stamped cl-tf-datatypes:pose-stamped) frame-id stamp)
     (declare (ignore frame-id stamp))
     pose-stamped))
 
@@ -60,22 +60,22 @@
   (labels ((transform-available-p (source-frame target-frame &key (time 0.0) (timeout 2.0))
              ;; Auxiliary predicate to check whether a tf-transform is available."
              (cl-tf2:ensure-transform-available
-              *tf2* source-frame target-frame))
+              *tf2-buffer* source-frame target-frame))
            (poses-equal-in-frame-p (pose-1 pose-2 compare-frame)
              ;; Predicate to check equality of two poses w.r.t. a given frame."
              (when (and (transform-available-p
-                         compare-frame (tf:frame-id pose-1)
-                         :time (tf:stamp pose-1))
+                         compare-frame (cl-tf-datatypes:frame-id pose-1)
+                         :time (cl-tf-datatypes:stamp pose-1))
                         (transform-available-p
-                         compare-frame (tf:frame-id pose-2)
-                         :time (tf:stamp pose-2)))
+                         compare-frame (cl-tf-datatypes:frame-id pose-2)
+                         :time (cl-tf-datatypes:stamp pose-2)))
                ;; assert: both poses can be transformed into 'compare-frame'
                (let ((pose-1-transformed
                        (cl-tf2:ensure-pose-stamped-transformed
-                        *tf2* pose-1 compare-frame :use-current-ros-time t))
+                        *tf2-buffer* pose-1 compare-frame :use-current-ros-time t))
                      (pose-2-transformed
                        (cl-tf2:ensure-pose-stamped-transformed
-                        *tf2* pose-2 compare-frame :use-current-ros-time t)))
+                        *tf2-buffer* pose-2 compare-frame :use-current-ros-time t)))
                  ;; compare transformed poses using pre-defined thresholds
                  (and (< (cl-transforms:v-dist
                       (cl-transforms:origin pose-1-transformed)

--- a/designators_ros/src/facts.lisp
+++ b/designators_ros/src/facts.lisp
@@ -44,7 +44,7 @@
     (lisp-fun cl-transforms:w ?orientation ?aw))
 
   (<- (pose-stamped ?pose ?frame-id ?stamp ?origin ?orientation)
-    (lisp-type ?pose tf:pose-stamped)
-    (lisp-fun tf:frame-id ?pose ?frame-id)
-    (lisp-fun tf:stamp ?pose ?stamp)
+    (lisp-type ?pose cl-tf-datatypes:pose-stamped)
+    (lisp-fun cl-tf-datatypes:frame-id ?pose ?frame-id)
+    (lisp-fun cl-tf-datatypes:stamp ?pose ?stamp)
     (pose ?pose ?origin ?orientation)))

--- a/designators_ros/src/package.lisp
+++ b/designators_ros/src/package.lisp
@@ -34,6 +34,6 @@
           #:cram-roslisp-common)
   (:import-from #:tf pose pose-stamped)
   (:import-from cram-roslisp-common *tf2-buffer*)
-  (:export pose pose-stamped *fixed-frame* *robot-base-frame*
+  (:export pose pose-stamped *fixed-frame* *robot-base-frame* *odom-frame*
            with-designator-solution-filter make-euclidean-distance-filter
            next-filtered-designator-solution))

--- a/designators_ros/src/package.lisp
+++ b/designators_ros/src/package.lisp
@@ -33,7 +33,7 @@
     (:use #:cl #:desig #:cut #:crs
           #:cram-roslisp-common)
   (:import-from #:tf pose pose-stamped)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer*)
   (:export pose pose-stamped *fixed-frame* *robot-base-frame*
            with-designator-solution-filter make-euclidean-distance-filter
            next-filtered-designator-solution))

--- a/location_costmap/location-costmap.asd
+++ b/location_costmap/location-costmap.asd
@@ -34,7 +34,7 @@
                cram-utilities
                roslisp-utilities
                cl-tf2
-               cl-tf
+               cl-tf-datatypes
                cram-roslisp-common
                cram-manipulation-knowledge
                nav_msgs-msg

--- a/location_costmap/location-costmap.asd
+++ b/location_costmap/location-costmap.asd
@@ -34,6 +34,7 @@
                cram-utilities
                roslisp-utilities
                cl-tf2
+               cl-tf
                cram-roslisp-common
                cram-manipulation-knowledge
                nav_msgs-msg

--- a/location_costmap/package.xml
+++ b/location_costmap/package.xml
@@ -21,6 +21,8 @@
   <build_depend>cram_utilities</build_depend>
   <build_depend>cram_roslisp_common</build_depend>
   <build_depend>cl_transforms</build_depend>
+  <build_depend>cl_tf</build_depend>
+  <build_depend>cl_tf2</build_depend>
   <build_depend>cram_math</build_depend>
   <build_depend>cram_language</build_depend>
   <build_depend>cram_reasoning</build_depend>
@@ -35,6 +37,8 @@
   <run_depend>cram_utilities</run_depend>
   <run_depend>cram_roslisp_common</run_depend>
   <run_depend>cl_transforms</run_depend>
+  <run_depend>cl_tf</run_depend>
+  <run_depend>cl_tf2</run_depend>
   <run_depend>cram_math</run_depend>
   <run_depend>cram_language</run_depend>
   <run_depend>cram_reasoning</run_depend>

--- a/location_costmap/package.xml
+++ b/location_costmap/package.xml
@@ -21,7 +21,7 @@
   <build_depend>cram_utilities</build_depend>
   <build_depend>cram_roslisp_common</build_depend>
   <build_depend>cl_transforms</build_depend>
-  <build_depend>cl_tf</build_depend>
+  <build_depend>cl_tf_datatypes</build_depend>
   <build_depend>cl_tf2</build_depend>
   <build_depend>cram_math</build_depend>
   <build_depend>cram_language</build_depend>
@@ -37,7 +37,7 @@
   <run_depend>cram_utilities</run_depend>
   <run_depend>cram_roslisp_common</run_depend>
   <run_depend>cl_transforms</run_depend>
-  <run_depend>cl_tf</run_depend>
+  <run_depend>cl_tf_datatypes</run_depend>
   <run_depend>cl_tf2</run_depend>
   <run_depend>cram_math</run_depend>
   <run_depend>cram_language</run_depend>

--- a/location_costmap/src/designator-integration.lisp
+++ b/location_costmap/src/designator-integration.lisp
@@ -62,7 +62,9 @@
   (list (cl-tf2:ensure-pose-stamped-transformed
          *tf2*
          (tf:make-pose-stamped
-          "/base_footprint" (roslisp:ros-time)
+          ;; asking for the current time results in extrapolation error
+          ;; because the available transforms in the buffer are older
+          "/base_footprint" 0.0 ;;(roslisp:ros-time)
           (tf:make-identity-vector)
           (tf:make-identity-rotation))
          "/map")))

--- a/location_costmap/src/designator-integration.lisp
+++ b/location_costmap/src/designator-integration.lisp
@@ -63,8 +63,10 @@
     (list (cl-tf2:ensure-pose-stamped-transformed
            *tf2-buffer*
            (cl-tf-datatypes:make-pose-stamped
-            designators-ros:*robot-base-frame* (roslisp:ros-time)
-            (cl-transforms:make-identity-vector) (cl-transforms:make-identity-rotation))
+            designators-ros:*robot-base-frame*
+            (roslisp:ros-time)
+            (cl-transforms:make-identity-vector)
+            (cl-transforms:make-identity-rotation))
            designators-ros:*fixed-frame*))))
 
 (defun location-costmap-generator (desig)
@@ -77,29 +79,30 @@
         nil))))
 
 (defun location-costmap-pose-validator (desig pose)
-  (when (typep pose 'cl-transforms:pose)
-    (let* ((cm (get-cached-costmap desig))
-           (p (cl-transforms:origin pose)))
-      (unless cm
-        (return-from location-costmap-pose-validator :unknown))
-      (handler-case
-          (let ((costmap-value (/ (get-map-value
-                                   cm
-                                   (cl-transforms:x p)
-                                   (cl-transforms:y p))
-                                  (get-cached-costmap-maxvalue cm)))
-                (costmap-heights (generate-heights
-                                  cm (cl-transforms:x p) (cl-transforms:y p))))
-            (when (> costmap-value *costmap-valid-solution-threshold*)
-              (cond ((not costmap-heights)
-                     :accept)
-                    ((find-if (lambda (height)
-                                (< (abs (- height (cl-transforms:z p)))
-                                   1e-3))
-                              costmap-heights)
-                     :accept))))
-        (cma:invalid-probability-distribution ()
-          :maybe-reject)))))
+  (if (typep pose 'cl-transforms:pose)
+      (let* ((cm (get-cached-costmap desig))
+             (p (cl-transforms:origin pose)))
+        (unless cm
+          (return-from location-costmap-pose-validator :unknown))
+        (handler-case
+            (let ((costmap-value (/ (get-map-value
+                                     cm
+                                     (cl-transforms:x p)
+                                     (cl-transforms:y p))
+                                    (get-cached-costmap-maxvalue cm)))
+                  (costmap-heights (generate-heights
+                                    cm (cl-transforms:x p) (cl-transforms:y p))))
+              (when (> costmap-value *costmap-valid-solution-threshold*)
+                (cond ((not costmap-heights)
+                       :accept)
+                      ((find-if (lambda (height)
+                                  (< (abs (- height (cl-transforms:z p)))
+                                     1e-3))
+                                costmap-heights)
+                       :accept))))
+          (cma:invalid-probability-distribution ()
+            :maybe-reject)))
+      :unknown))
 
 (register-location-generator
  15 robot-current-pose-generator

--- a/location_costmap/src/designator-integration.lisp
+++ b/location_costmap/src/designator-integration.lisp
@@ -60,14 +60,19 @@
 (defun robot-current-pose-generator (desig)
   (declare (ignore desig))
   (when *tf2-buffer*
-    (list (cl-tf2:ensure-pose-stamped-transformed
-           *tf2-buffer*
-           (cl-tf-datatypes:make-pose-stamped
-            designators-ros:*robot-base-frame*
-            (roslisp:ros-time)
-            (cl-transforms:make-identity-vector)
-            (cl-transforms:make-identity-rotation))
-           designators-ros:*fixed-frame*))))
+    (handler-case
+        (let ((robot-pose
+                (cl-tf2:transform-pose
+                 *tf2-buffer*
+                 :pose (cl-tf-datatypes:make-pose-stamped
+                        designators-ros:*robot-base-frame*
+                        (roslisp:ros-time)
+                        (cl-transforms:make-identity-vector)
+                        (cl-transforms:make-identity-rotation))
+                 :target-frame designators-ros:*fixed-frame*
+                 :timeout cram-roslisp-common:*tf-default-timeout*)))
+          (list robot-pose))
+      (cl-tf2:tf2-server-error () nil))))
 
 (defun location-costmap-generator (desig)
   (let ((costmap (get-cached-costmap desig)))

--- a/location_costmap/src/designator-integration.lisp
+++ b/location_costmap/src/designator-integration.lisp
@@ -59,15 +59,13 @@
 
 (defun robot-current-pose-generator (desig)
   (declare (ignore desig))
-  (list (cl-tf2:ensure-pose-stamped-transformed
-         *tf2*
-         (tf:make-pose-stamped
-          ;; asking for the current time results in extrapolation error
-          ;; because the available transforms in the buffer are older
-          "/base_footprint" 0.0 ;;(roslisp:ros-time)
-          (tf:make-identity-vector)
-          (tf:make-identity-rotation))
-         "/map")))
+  (when *tf2*
+    (list (cl-tf2:ensure-pose-stamped-transformed
+           *tf2*
+           (cl-tf:make-pose-stamped
+            designators-ros:*robot-base-frame* (roslisp:ros-time)
+            (cl-tf:make-identity-vector) (cl-tf:make-identity-rotation))
+           designators-ros:*fixed-frame*))))
 
 (defun location-costmap-generator (desig)
   (let ((costmap (get-cached-costmap desig)))

--- a/location_costmap/src/designator-integration.lisp
+++ b/location_costmap/src/designator-integration.lisp
@@ -59,12 +59,12 @@
 
 (defun robot-current-pose-generator (desig)
   (declare (ignore desig))
-  (when *tf2*
+  (when *tf2-buffer*
     (list (cl-tf2:ensure-pose-stamped-transformed
-           *tf2*
-           (cl-tf:make-pose-stamped
+           *tf2-buffer*
+           (cl-tf-datatypes:make-pose-stamped
             designators-ros:*robot-base-frame* (roslisp:ros-time)
-            (cl-tf:make-identity-vector) (cl-tf:make-identity-rotation))
+            (cl-transforms:make-identity-vector) (cl-transforms:make-identity-rotation))
            designators-ros:*fixed-frame*))))
 
 (defun location-costmap-generator (desig)

--- a/location_costmap/src/facts.lisp
+++ b/location_costmap/src/facts.lisp
@@ -66,8 +66,8 @@ quaternions to face towards `position'"
   "Returns a function that takes an X and Y coordinate and returns a
 quaternion to face towards `position'"
   (let* ((point (etypecase position
-                  (tf:pose (tf:origin position))
-                  (tf:3d-vector position)))
+                  (cl-transforms:pose (cl-transforms:origin position))
+                  (cl-transforms:3d-vector position)))
          (p-rel (cl-transforms:v- point (cl-transforms:make-3d-vector x y 0))))
     (atan (cl-transforms:y p-rel) (cl-transforms:x p-rel))))
 

--- a/location_costmap/src/location-costmap.lisp
+++ b/location_costmap/src/location-costmap.lisp
@@ -222,7 +222,7 @@ calls the generator functions and runs normalization."
 (defmethod costmap-samples ((map location-costmap) &key sampling-function)
   (lazy-mapcan (lambda (sample-point)
                  (lazy-mapcar (lambda (orientation)
-                                (tf:make-pose sample-point orientation))
+                                (cl-transforms:make-pose sample-point orientation))
                               (generate-orientations
                                map
                                (cl-transforms:x sample-point)

--- a/location_costmap/src/package.lisp
+++ b/location_costmap/src/package.lisp
@@ -106,7 +106,7 @@
            #:costmap-padding #:costmap-manipulation-padding
            #:costmap-in-reach-distance #:costmap-reach-minimal-distance)
   (:import-from #:cram-math invalid-probability-distribution)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer*)
   (:shadowing-import-from :roslisp-utilities #:startup-ros #:shutdown-ros
                           #:register-ros-init-function #:register-ros-cleanup-function
                           #:rosify-lisp-name #:lispify-ros-name)

--- a/location_costmap/src/visualization.lisp
+++ b/location_costmap/src/visualization.lisp
@@ -107,15 +107,15 @@ respectively."
           (dotimes (col (array-dimension map-array 1))
             (let ((curr-val (aref map-array row col)))
               (when (> curr-val threshold)
-                (let ((pose (tf:make-pose
-                             (tf:make-3d-vector
+                (let ((pose (cl-transforms:make-pose
+                             (cl-transforms:make-3d-vector
                               (+ (* col resolution) origin-x)
                               (+ (* row resolution) origin-y)
                               (+ z (or (when elevate-costmap
                                          (/ curr-val max-val))
                                        0.0)))
-                             (tf:axis-angle->quaternion
-                              (tf:make-3d-vector 1.0 0.0 0.0) 0.0)))
+                             (cl-transforms:axis-angle->quaternion
+                              (cl-transforms:make-3d-vector 1.0 0.0 0.0) 0.0)))
                       (color (cond (hsv-colormap
                                     (hsv->rgb (* 360 (/ curr-val
                                                         max-val))
@@ -145,7 +145,7 @@ respectively."
                                       (action) (roslisp-msg-protocol:symbol-code
                                                 'visualization_msgs-msg:marker
                                                 :add)
-                                      (pose) (tf:pose->msg pose)
+                                      (pose) (cl-tf2:to-msg pose)
                                       (x scale) resolution
                                       (y scale) resolution
                                       (z scale) resolution
@@ -243,7 +243,7 @@ respectively."
                              (stamp header) (ros-time)
                              (frame_id header)
                              (typecase pose
-                               (tf:pose-stamped (tf:frame-id pose))
+                               (cl-tf-datatypes:pose-stamped (cl-tf-datatypes:frame-id pose))
                                (t "/map"))
                              ns "kipla_locations"
                              id (or id (incf current-index))

--- a/semantic_map_collision_environment/src/collision-objects.lisp
+++ b/semantic_map_collision_environment/src/collision-objects.lisp
@@ -186,7 +186,7 @@
           :name name
           :type type
           :index 0
-          :pose (transform-pose
+          :pose (cl-transforms:transform-pose
                  pose-tf
                  (make-pose
                   (make-3d-vector
@@ -198,7 +198,7 @@
           :name name
           :type type
           :index 1
-          :pose (transform-pose
+          :pose (cl-transforms:transform-pose
                  pose-tf
                  (make-pose
                   (make-3d-vector
@@ -210,7 +210,7 @@
           :name name
           :type type
           :index 2
-          :pose (transform-pose
+          :pose (cl-transforms:transform-pose
                  pose-tf
                  (make-pose
                   (make-3d-vector
@@ -222,7 +222,7 @@
           :name name
           :type type
           :index 3
-          :pose (transform-pose
+          :pose (cl-transforms:transform-pose
                  pose-tf
                  (make-pose
                   (make-3d-vector
@@ -234,7 +234,7 @@
           :name name
           :type type
           :index 4
-          :pose (transform-pose
+          :pose (cl-transforms:transform-pose
                  pose-tf
                  (make-pose
                   (make-3d-vector
@@ -246,7 +246,7 @@
           :name name
           :type type
           :index 5
-          :pose (transform-pose
+          :pose (cl-transforms:transform-pose
                  pose-tf
                  (make-pose
                   (make-3d-vector

--- a/semantic_map_collision_environment/src/package.lisp
+++ b/semantic_map_collision_environment/src/package.lisp
@@ -39,7 +39,7 @@
            remove-semantic-map-collision-objects
            update-sem-map-obj-pose)
   (:import-from semantic-map-utils semantic-map-name)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer*)
   (:shadowing-import-from :roslisp-utilities #:startup-ros #:shutdown-ros
                           #:register-ros-init-function #:register-ros-cleanup-function
                           #:rosify-lisp-name #:lispify-ros-name))

--- a/semantic_map_collision_environment/src/ros-connection.lisp
+++ b/semantic_map_collision_environment/src/ros-connection.lisp
@@ -63,8 +63,8 @@
       (with-slots (pose dimensions) obj
         (let* ((obj-name (string-upcase (make-collision-obj-name obj)))
                (pose-stamped (cl-tf2:ensure-pose-stamped-transformed
-                              *tf2*
-                              (tf:pose->pose-stamped "/map" 0.0 pose)
+                              *tf2-buffer*
+                              (cl-tf-datatypes:pose->pose-stamped "/map" 0.0 pose)
                               "/odom_combined")))
             (moveit:register-collision-object
              obj-name
@@ -127,7 +127,7 @@
      id index
      type 1
      action 0
-     pose (tf:pose->msg pose)
+     pose (cl-tf2:to-msg pose)
      (x scale) (x dimensions)
      (y scale) (y dimensions)
      (z scale) (z dimensions)

--- a/semantic_map_collision_environment/src/ros-connection.lisp
+++ b/semantic_map_collision_environment/src/ros-connection.lisp
@@ -62,10 +62,12 @@
     (dolist (obj objs)
       (with-slots (pose dimensions) obj
         (let* ((obj-name (string-upcase (make-collision-obj-name obj)))
-               (pose-stamped (cl-tf2:ensure-pose-stamped-transformed
+               (pose-stamped (cl-tf2:transform-pose
                               *tf2-buffer*
-                              (cl-tf-datatypes:pose->pose-stamped "/map" 0.0 pose)
-                              "/odom_combined")))
+                              :pose (cl-tf-datatypes:pose->pose-stamped
+                                     designators-ros:*fixed-frame* 0.0 pose)
+                              :target-frame designators-ros:*odom-frame*
+                              :timeout cram-roslisp-common:*tf-default-timeout*)))
             (moveit:register-collision-object
              obj-name
              :primitive-shapes (list (roslisp:make-msg

--- a/semantic_map_costmap/src/cost-functions.lisp
+++ b/semantic_map_costmap/src/cost-functions.lisp
@@ -199,41 +199,41 @@
                                          (cl-transforms:y obj-max)
                                          resolution origin-y)))
                    (let* ((mean 0.7d0)
-                          (x-min (tf:x obj-min))
-                          (x-max (tf:x obj-max))
-                          (y-min (tf:y obj-min))
-                          (y-max (tf:y obj-max))
+                          (x-min (cl-transforms:x obj-min))
+                          (x-max (cl-transforms:x obj-max))
+                          (y-min (cl-transforms:y obj-min))
+                          (y-max (cl-transforms:y obj-max))
                           (x-len (- x-max x-min))
                           (y-len (- y-max y-min))
                           (x-dominant (> x-len y-len))
                           (poses
                             (cond (x-dominant
                                    (list
-                                    (tf:make-pose
-                                     (tf:make-3d-vector
-                                      (+ (tf:x (tf:origin obj-pose))
+                                    (cl-transforms:make-pose
+                                     (cl-transforms:make-3d-vector
+                                      (+ (cl-transforms:x (cl-transforms:origin obj-pose))
                                          (/ y-len 2))
-                                      (+ (tf:y (tf:origin obj-pose))
+                                      (+ (cl-transforms:y (cl-transforms:origin obj-pose))
                                          (/ y-len 2))
                                       0.0d0)
-                                     (tf:make-identity-rotation))))
+                                     (cl-transforms:make-identity-rotation))))
                                   (t (list
-                                      (tf:make-pose
-                                       (tf:make-3d-vector
+                                      (cl-transforms:make-pose
+                                       (cl-transforms:make-3d-vector
                                         (+ x-min
                                            (/ x-len 2))
                                         (+ y-min
                                            (/ x-len 2))
                                         0.0d0)
-                                       (tf:make-identity-rotation))
-                                      (tf:make-pose
-                                       (tf:make-3d-vector
+                                       (cl-transforms:make-identity-rotation))
+                                      (cl-transforms:make-pose
+                                       (cl-transforms:make-3d-vector
                                         (+ x-min
                                            (/ x-len 2))
                                         (- y-max
                                            (/ x-len 2))
                                         0.0d0)
-                                       (tf:make-identity-rotation))))))
+                                       (cl-transforms:make-identity-rotation))))))
                           (meancovs (mapcar
                                      (lambda (pose)
                                        (location-costmap::2d-pose-covariance


### PR DESCRIPTION
This is a part of a series of pull requests concerning the switch from TF to TF2.
All the PRs are:

roslisp_common: https://github.com/ros/roslisp_common/pull/23
cram_highlevel: https://github.com/cram-code/cram_highlevel/pull/46
cram_physics: https://github.com/cram-code/cram_physics/pull/23
cram_pr2: https://github.com/cram-code/cram_pr2/pull/10
cram_bridge: https://github.com/cram-code/cram_bridge/pull/21

There is still a problem with TF for projection as the joint state publisher from moveit interferes with the transforms published from projection. This should not affect the execution on the real robot.

One important change is to use `transform-pose` instead of `ensure-pose-...` as the latter would block infinitely if a transform would not be provided to TF. The function `transfrom-pose` has an argument called `timeout` which specifies in seconds how long to wait for the transform before giving up. The default value is specified in `cram-roslisp-common:*tf-default-timeout*`. So, before starting your scenarios set it up for a reasonable value, e.g. 10 seconds or more when working on a real robot.
