### PR TITLE
Shadow the extremum function

### DIFF
--- a/cram_plan_knowledge/src/package.lisp
+++ b/cram_plan_knowledge/src/package.lisp
@@ -39,6 +39,7 @@
           #:cram-execution-trace)
   (:nicknames #:plan-knowledge)
   (:shadowing-import-from #:cpl #:name)
+  (:shadowing-import-from #:cram-utilities #:extremum)
   (:import-from #:designators-ros pose pose-stamped)
   (:shadow event)
   (:export #:clear-belief

--- a/cram_plan_library/src/package.lisp
+++ b/cram_plan_library/src/package.lisp
@@ -39,6 +39,7 @@
         #:cram-plan-knowledge
         #:cram-plan-failures
         #:alexandria)
+  (:shadowing-import-from #:cram-utilities #:extremum)
   (:nicknames :plan-lib)
   (:export #:achieve
            #:perform

--- a/cram_task_knowledge/src/package.lisp
+++ b/cram_task_knowledge/src/package.lisp
@@ -36,6 +36,7 @@
         #:roslisp
         #:cram-roslisp-common
         #:alexandria)
+  (:shadowing-import-from #:cram-utilities #:extremum)
   (:export table-setting-object
            situation?
            meal-time)


### PR DESCRIPTION
Newer versions of alexandria export a function of the same name. To
remove this conflict, the symbol from alexandria will be shadowed.